### PR TITLE
Deprecated create_ref doesn't have a default so don't validate boolean

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -96,7 +96,7 @@ export async function run(): Promise<void> {
 	// originally called create_ref but was renamed to create_tag
 	if (
 		core.getBooleanInput('create_tag', { required: false }) ||
-		core.getBooleanInput('create_ref', { required: false })
+		core.getInput('create_ref', { required: false })
 	) {
 		try {
 			await createTag(


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-io/deploy-to-balena-action/issues/77