### PR TITLE
Refactor releaseId regex to be more specific to prevent matching wron…

### DIFF
--- a/src/balena-utils.ts
+++ b/src/balena-utils.ts
@@ -95,7 +95,7 @@ export async function push(
 		buildProcess.stdout.on('data', (data: Buffer) => {
 			const msg = stripAnsi(data.toString());
 			core.info(msg);
-			const match = msg.match(/\(id: (\d*)\)/);
+			const match = msg.match(/Release: .{32} \(id: (\d*)\)/);
 			if (match) {
 				releaseId = match[1];
 			}


### PR DESCRIPTION
I saw that build logs now introduce another Id that the regex would match...this makes the regex more specific