### PR TITLE
Disable resin-ci builds

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,15 +1,3 @@
 ---
-docker:
-  builds:
-    - path: .
-      dockerfile: Dockerfile
-      docker_repo: balena-io/balena-ci
-      publish: false
-npm:
-  platforms:
-    - name: linux
-      os: ubuntu
-      architecture: x86_64
-      node_versions:
-        - "12"
-        - "14"
+docker: false
+npm: false


### PR DESCRIPTION
I didn't like that they were making my commits have a red checkmark plus it's unnecessary work for resin-ci

This undoes https://github.com/balena-io/deploy-to-balena-action/pull/50

Interested to hear your thought @klutchell 