### PR TITLE
Remove create ref

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,15 +1,3 @@
 ---
-docker:
-  builds:
-    - path: .
-      dockerfile: Dockerfile
-      docker_repo: balena-io/balena-ci
-      publish: false
-npm:
-  platforms:
-    - name: linux
-      os: ubuntu
-      architecture: x86_64
-      node_versions:
-        - "12"
-        - "14"
+docker: false
+npm: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,9 +13,7 @@ const inputs: Inputs = {
 	environment: core.getInput('environment', { required: false }),
 	cache: core.getBooleanInput('cache', { required: false }),
 	versionbot: core.getBooleanInput('versionbot', { required: false }),
-	createTag:
-		core.getBooleanInput('create_tag', { required: false }) ||
-		core.getBooleanInput('create_ref', { required: false }),
+	createTag: core.getBooleanInput('create_tag', { required: false }),
 	source: core.getInput('source', { required: false }),
 	githubToken: core.getInput('github_token', { required: false }),
 };

--- a/tests/src/main.spec.ts
+++ b/tests/src/main.spec.ts
@@ -42,7 +42,6 @@ describe('src/main', () => {
 				cache: false,
 				versionbot: true,
 				create_tag: true,
-				create_ref: false,
 			}[inputName];
 		});
 	});


### PR DESCRIPTION
If you remove a value from action.yml and try to access it and use required: false you will crash because the action runner did not set a default value which normally is specified in action.yml.

Removing create_ref in the code makes sense since it's not in the action.yml anymore and keeping it for backwards compatibility just caused this issue.