### PR TITLE
Experiment with the node-cli repo type

### DIFF
--- a/repo.yml
+++ b/repo.yml
@@ -1,4 +1,4 @@
-type: node
+type: node-cli
 release: github
 publishMetadata: true
 upstream:


### PR DESCRIPTION
In theory this repo type can publish Github Releases.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>

DO NOT MERGE