### PR TITLE
action: Only tag final releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Inputs are provided using the `with:` section of your workflow YML file.
 | environment | Domain of API hosting your fleets | false | balena-cloud.com |
 | cache | If a release matching the commit already exists do not build again | false | true |
 | versionbot | Tells action to use Versionbot branch for versioning | false | false |
-| create_tag | Create a ref on the git commit with the release version | false | false |
+| create_tag | Create a tag on the git commit with the final release version | false | false |
 | source | Specify a source directory (for `Dockerfile.template` or `docker-compose.yml`) | false | root directory |
 | layer_cache | Use cached layers of previously built images for this project | false | true |
 

--- a/action.yml
+++ b/action.yml
@@ -28,11 +28,11 @@ inputs:
     required: false
     default: true
   create_tag:
-    description: 'Tag the git commit with the balena release version'
+    description: 'Tag the git commit with the final balena release version'
     required: false
     default: false
   create_ref:
-    description: 'Tag the git commit with the balena release version'
+    description: 'Tag the git commit with the final balena release version'
     required: false
     default: false
   cache:

--- a/tests/src/action.spec.ts
+++ b/tests/src/action.spec.ts
@@ -175,7 +175,7 @@ describe('src/action', () => {
 				},
 			};
 			// @ts-expect-error
-			await action.run(prContext, inputs);
+			await action.run(prContext, { ...inputs, createTag: true });
 			// Check that the last arg (buildOptions) does not contain draft: true
 			expect(pushStub.lastCall.lastArg).to.deep.equal({
 				noCache: false,
@@ -184,6 +184,7 @@ describe('src/action', () => {
 					pullRequestId: 4423422,
 				},
 			});
+			expect(createTagStub).to.have.not.been.called;
 		});
 
 		it('finalizes when a PR closes', async () => {
@@ -214,17 +215,20 @@ describe('src/action', () => {
 				isFinal: false,
 			});
 			// @ts-expect-error
-			await action.run(prContext, inputs);
+			await action.run(prContext, { ...inputs, createTag: true });
 			// Check that the release was finalized
 			expect(finalizeStub).to.have.been.calledWith(123456);
 			finalizeStub.restore();
+			expect(createTagStub).to.have.been.called;
+			// Check that create tag value was passed
+			expect(createTagStub.lastCall.args[1]).to.equal('v0.5.6');
 		});
 	});
 
 	describe('Main workflow', () => {
 		it('builds a finalized release', async () => {
 			// @ts-expect-error
-			await action.run(context, inputs);
+			await action.run(context, { ...inputs, createTag: true });
 			// Check that the last arg (buildOptions) does not contain draft: true
 			expect(pushStub.lastCall.lastArg).to.deep.equal({
 				noCache: false,
@@ -233,6 +237,9 @@ describe('src/action', () => {
 					sha: 'fba0317620597271695087c168c50d8c94975a29',
 				},
 			});
+			expect(createTagStub).to.have.been.called;
+			// Check that create tag value was passed
+			expect(createTagStub.lastCall.args[1]).to.equal('v0.5.6');
 		});
 	});
 });


### PR DESCRIPTION
Tagging draft releases creates a lot of clutter and references to commits that no longer exist. Instead just tag final releases.

Change-type: minor
Signed-off-by: Kyle Harding <kyle@balena.io>