### PR TITLE
Pipe CLI whoami test to /dev/null

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ set -eo pipefail
 balena login --token ${BALENA_TOKEN} 
 
 # Test CLI is working
-balena whoami 
+balena whoami > /dev/null 
 
 # Test git is working
 git --version

--- a/src/balena-utils.ts
+++ b/src/balena-utils.ts
@@ -22,6 +22,7 @@ const DEFAULT_BUILD_OPTIONS: Partial<BuildOptions> = {
 let sdk: ReturnType<typeof balena.getSdk> | null = null;
 
 export async function init(endpoint: string, token: string) {
+	core.info(`Initializing SDK for https://api.${endpoint})`);
 	// Specify API endpoint
 	sdk = balena.getSdk({
 		apiUrl: `https://api.${endpoint})}/`,


### PR DESCRIPTION
Not redacting environment provided because in order for you to see the logs you need access to the repo and if you have access to the repo then you'll also be able to see the environment input provided in the workflow.