### PR TITLE
Added `registry-secrets` input to authenticate with private registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,23 @@ Inputs are provided using the `with:` section of your workflow YML file.
 | create_tag | Create a tag on the git commit with the final release version | false | false |
 | source | Specify a source directory (for `Dockerfile.template` or `docker-compose.yml`) | false | root directory |
 | layer_cache | Use cached layers of previously built images for this project | false | true |
+| registry_secrets | JSON string containing image registry credentials used to pull base images | false | |
 
 `balena_token` and other tokens needs to be stored in GitHub as an [encrypted secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) that GitHub Actions can access. 
 
 `environment` can be used to specify a custom domain for the backend that will build and deploy your release. If for example you want to deploy to staging environment, you would set it to `balena-staging.com` or if you run your own instance of balenaCloud such as openBalena then specify your domain here.
+
+`registry_secrets` uses a standard secrets.json file format that contains the registry domain with username/password or token inside. You can pass a JSON file as a string like so in your workflow file:
+
+```
+         registry_secrets: |
+            {
+              "ghcr.io": {
+                "username": "${{ secrets.REGISTRY_USER }}",
+                "password": "${{ secrets.REGISTRY_PASS }}"
+              }
+            } 
+```
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -44,9 +44,13 @@ inputs:
     required: false
     default: ''
   layer_cache:
-    description: "Use cached layers of previously built images for this project"
+    description: 'Use cached layers of previously built images for this project'
     required: false
     default: true 
+  registry_secrets:
+    description: 'Image registry credentrials (Balena secrets.json)'
+    required: false
+    default: '' 
 outputs:
   release_id:
     description: 'ID of the release built'
@@ -58,3 +62,4 @@ runs:
   env:
     BALENA_TOKEN: ${{ inputs.balena_token }}
     BALENA_URL: ${{ inputs.environment }}
+    REGISTRY_SECRETS: ${{ inputs.registry_secrets }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,5 +17,10 @@ balena whoami > /dev/null
 # Test git is working
 git --version
 
+if [[ "${REGISTRY_SECRETS}" != "" ]]; then
+  mkdir -p "$HOME/.balena/"
+  echo ${REGISTRY_SECRETS} > "$HOME/.balena/secrets.json"
+fi
+
 # Run action
 exec node /usr/src/app/build/src/main.js


### PR DESCRIPTION
This input is a string representation of a secrets.json file. This means, you do not pass a username and password or token. You instead make your workflow yaml use a [literal scalar](https://yaml.org/spec/1.2-old/spec.html#id2795688) which mimics a secrets.json file. This syntax allows for infinite secrets.json combinations so the action doesn't have to know if you're setting a token vs user/pass or what registry it is for.

The action would therefore look like this:

```
      - uses: balena-io/balena-ci@add-registry-auth
        name: 'Deploy to miguel/${{ matrix.fleet }}'
        id: build
        with:
          balena_token: ${{ secrets.BALENA_STAGING_TOKEN }} 
          environment: balena-staging.com
          fleet: 'miguel/${{ matrix.fleet }}' 
          registry_secrets: |
            {
              "ghcr.io": {
                "username": "${{ secrets.REGISTRY_USER }}",
                "password": "${{ secrets.REGISTRY_PASS }}"
              }
            } 
```