### PR TITLE
Only build when event is on master

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build-and-push-image:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
I noticed the workflow was running on versionbot branches for some reason. This should prevent that.