### PR TITLE
Build images on tagged commits

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -2,10 +2,8 @@ name: Create and publish a Docker image
 
 on:
   push:
-    paths:
-      - '.versionbot/CHANGELOG.yml'
-      - 'CHANGELOG.md'
-
+    tags:
+      - 'v*'
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -39,6 +37,5 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
last setup was causing the meta-data parser action to tag the images as master.. I only wanted version tags. 