### PR TITLE
Run image build on base_ref master

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build-and-push-image:
-    if: github.ref == 'refs/heads/master'
+    if: github.event.base_ref == "refs/heads/master"
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
old setup would run on tags but because ref was not master it was ignored.