### PR TITLE
Don't check author of tag

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -4,13 +4,13 @@ on:
   push:
     tags:
       - 'v*'
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push-image:
-    if: "!contains(github.event.head_commit.author.name, 'versionist’)"
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
I initially added it to avoid unwanted packages being built but you need write permission to the repo.