### PR TITLE
Add git WORKDIR as git safe directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,9 @@ balena whoami > /dev/null
 # Test git is working
 git --version
 
+# Fix for https://github.com/actions/checkout/issues/760
+git config --global --add safe.directory /github/workspace 
+
 if [[ "${REGISTRY_SECRETS}" != "" ]]; then
   mkdir -p "$HOME/.balena/"
   echo ${REGISTRY_SECRETS} > "$HOME/.balena/secrets.json"


### PR DESCRIPTION
Mitigation for https://github.com/actions/checkout/issues/760 until we can upgrade git to v3.35.2

https://github.blog/2022-04-12-git-security-vulnerability-announced/

Change-type: patch
Signed-off-by: 20k-ultra <3946250+20k-ultra@users.noreply.github.com>