### PR TITLE
Enable publishing docker image to dockerhub via balenaCI

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -3,8 +3,8 @@ docker:
   builds:
     - path: .
       dockerfile: Dockerfile
-      docker_repo: balena-io/balena-ci
-      publish: false
+      docker_repo: balena/deploy-to-balena-action
+      publish: true
 npm:
   platforms:
     - name: linux


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-io/deploy-to-balena-action/issues/27