### PR TITLE
patch: Change `master` branch to `main` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ on:
  pull_request:
     types: [opened, synchronize, closed]
     branches:
+      - main
       - master
 
 jobs:
@@ -80,9 +81,9 @@ In the sample config shown above under [usage](#usage) we are triggering the act
 
 Now, devices tracking latest will automatically download the release and this was all powered through your github workflow!
 
-### Commit to master
+### Commit to main
 
-This workflow is useful if you push directly to master. This workflow will build your release and notice that it is merging directly to the default branch so not build them as drafts. Devices tracking latest will automatically download these new releases.
+This workflow is useful if you push directly to main. This workflow will build your release and notice that it is merging directly to the default branch so not build them as drafts. Devices tracking latest will automatically download these new releases.
 
 To use this workflow just replace the events found from the sample workflow config under [usage](#usage) with:
 
@@ -90,7 +91,7 @@ To use this workflow just replace the events found from the sample workflow conf
 on:
   push:
     branches:
-      - master
+      - main
 ```
 
 ### Additional comments about workflows


### PR DESCRIPTION
Changed references from `master` branch to `main` in alignment with GitHub's shift to a new default.

GitHub repos now default to `main` instead of `master`. When I created a new repo which had a default branch of `main` and I used the example from the README the workflow didn't trigger because it was pointing to `master`. This change amends the README to refer to the new default, and changes the example action to trigger on both `master` and `main` branches to be backwards compatible. 
 
See [this article]( https://www.zdnet.com/article/github-to-replace-master-with-main-starting-next-month/#:~:text=Starting%20next%20month,%20all%20new,them%20with%20more%20inclusive%20terms) for changes to GitHub default.