### PR TITLE
Prefer balena_api_key input to balena_token input for Flowzone

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
       - uses: balena-io/deploy-to-balena-action@master
         id: build
         with:
-          balena_token: ${{ secrets.BALENA_TOKEN }}
+          balena_api_key: ${{ secrets.BALENA_API_KEY }}
           fleet: my_org/sample_fleet
       - name: Log release ID built
         run: echo "Built release ID ${{ steps.build.outputs.release_id }}"
@@ -34,7 +34,7 @@ Inputs are provided using the `with:` section of your workflow YML file.
 
 | key | Description | Required | Default |
 | --- | --- | --- | --- |
-| balena_token | API key to balenaCloud | true | |
+| balena_api_key | API key to balenaCloud | true | |
 | fleet | The slug of the fleet (eg: `my_org/sample_fleet`) for which the release is for | true | |
 | environment | Domain of API hosting your fleets | false | balena-cloud.com |
 | cache | If a release matching the commit already exists do not build again | false | true |
@@ -45,7 +45,7 @@ Inputs are provided using the `with:` section of your workflow YML file.
 | registry_secrets | JSON string containing image registry credentials used to pull base images | false | |
 | default_branch | Used to finalize a release when code is pushed to this branch | false | Repo configured [default branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch) |
 
-`balena_token` and other tokens needs to be stored in GitHub as an [encrypted secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) that GitHub Actions can access. 
+`balena_api_key` and other tokens needs to be stored in GitHub as an [encrypted secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) that GitHub Actions can access. 
 
 `environment` can be used to specify a custom domain for the backend that will build and deploy your release. If for example you want to deploy to staging environment, you would set it to `balena-staging.com` or if you run your own instance of balenaCloud such as openBalena then specify your domain here.
 

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,14 @@ branding:
   icon: code
   color: blue
 inputs:
+  balena_api_key:
+    description: Your balenaCloud API key.
+    required: false
+    default: ""
   balena_token:
-    description: Your balenaCloud API token
-    required: true
+    description: Deprecated; Use balena_api_key instead.
+    required: false
+    default: ""
   fleet:
     description: Name of the fleet you want to build the release for
     required: true
@@ -63,7 +68,10 @@ outputs:
 runs:
   using: docker
   image: docker://ghcr.io/balena-io/deploy-to-balena-action:v0.20.6
+  pre-entrypoint: echo "::warning::balena_token is deprecated, please use balena_api_key instead."
+  pre-if: ${{ inputs.balena_token != "" }}
   env:
+    BALENA_API_KEY: ${{ inputs.balena_api_key }}
     BALENA_TOKEN: ${{ inputs.balena_token }}
     BALENA_URL: ${{ inputs.environment }}
     REGISTRY_SECRETS: ${{ inputs.registry_secrets }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,10 +6,14 @@ export BALENARC_BALENA_URL
 
 set -e
 
-[ -z "${BALENA_TOKEN}" ] && echo "BALENA_TOKEN input cannot be empty" && exit 1
+BALENA_API_KEY=${BALENA_API_KEY:=${BALENA_TOKEN:=}}
 
-# Authenticate CLI with token
-balena login --token "${BALENA_TOKEN}" 
+[ -z "${BALENA_API_KEY}" ] && \
+  echo "::error::One of balena_api_key or balena_token inputs must not be empty" && \
+  exit 1
+
+# Authenticate CLI with API key
+balena login --token "${BALENA_API_KEY}"
 
 # Test CLI is working
 balena whoami > /dev/null 

--- a/events/close-pr/env.example
+++ b/events/close-pr/env.example
@@ -1,7 +1,7 @@
 # PRIMARY GITHUB CONTEXT VARIABLES + ACTION INPUTS (Must set these for the action to work)
 
 INPUT_FLEET= # name of fleet
-INPUT_BALENA_TOKEN= # personal access token
+INPUT_BALENA_API_KEY= # personal access token
 INPUT_ENVIRONMENT=balena-cloud.com
 INPUT_VERSIONBOT=false
 INPUT_CACHE=true

--- a/events/open-pr/env.example
+++ b/events/open-pr/env.example
@@ -1,7 +1,7 @@
 # PRIMARY GITHUB CONTEXT VARIABLES + ACTION INPUTS (Must set these for the action to work)
 
 INPUT_FLEET= # name of fleet
-INPUT_BALENA_TOKEN= # personal access token
+INPUT_BALENA_API_KEY= # personal access token
 INPUT_ENVIRONMENT=balena-cloud.com
 INPUT_VERSIONBOT=false
 INPUT_CACHE=true

--- a/events/push/env.example
+++ b/events/push/env.example
@@ -1,7 +1,7 @@
 # PRIMARY GITHUB CONTEXT VARIABLES + ACTION INPUTS (Must set these for the action to work)
 
 INPUT_FLEET= # name of fleet
-INPUT_BALENA_TOKEN= # personal access token
+INPUT_BALENA_API_KEY= # personal access token
 INPUT_ENVIRONMENT=balena-cloud.com
 INPUT_VERSIONBOT=false
 INPUT_CACHE=true

--- a/events/sync-pr/env.example
+++ b/events/sync-pr/env.example
@@ -1,7 +1,7 @@
 # PRIMARY GITHUB CONTEXT VARIABLES + ACTION INPUTS (Must set these for the action to work)
 
 INPUT_FLEET= # name of fleet
-INPUT_BALENA_TOKEN= # personal access token
+INPUT_BALENA_API_KEY= # personal access token
 INPUT_ENVIRONMENT=balena-cloud.com
 INPUT_VERSIONBOT=false
 INPUT_CACHE=true

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,8 @@ const WORKSPACE =
 
 // Capture inputs
 const inputs: Inputs = {
-	balenaToken: core.getInput('balena_token', { required: true }),
+	balenaApiKey: core.getInput('balena_api_key', { required: false }),
+	balenaToken: core.getInput('balena_token', { required: false }),
 	fleet: core.getInput('fleet', { required: true }),
 	environment: core.getInput('environment', { required: false }),
 	cache: core.getBooleanInput('cache', { required: false }),
@@ -32,7 +33,10 @@ const inputs: Inputs = {
 		// Initialize github client
 		githubUtils.init(inputs.githubToken);
 		// Initialize balena SDK
-		await balenaUtils.init(inputs.environment, inputs.balenaToken);
+		await balenaUtils.init(
+			inputs.environment,
+			inputs.balenaApiKey || inputs.balenaToken,
+		);
 		await action.run(context, inputs);
 	} catch (e: any) {
 		core.setFailed(e.message);

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export type Inputs = {
 	fleet: string;
 	source: string;
 	environment: string;
+	balenaApiKey: string;
 	balenaToken: string;
 	githubToken: string;
 	cache: boolean;

--- a/tests/src/main.spec.ts
+++ b/tests/src/main.spec.ts
@@ -38,6 +38,7 @@ describe('src/main', () => {
 		// Return some sample inputs
 		getInputStub.callsFake((inputName: string) => {
 			return {
+				balena_api_key: 'balenaApiKeyExample',
 				balena_token: 'balenaTokenExample',
 				fleet: 'my-org/my-fleet',
 				environment: 'balena-cloud.com',
@@ -75,7 +76,7 @@ describe('src/main', () => {
 		balenaUtilStub.restore();
 	});
 
-	it('initilizes action correctly', async () => {
+	it('initializes action correctly', async () => {
 		const setFailedStub = stub(core, 'setFailed');
 		// Actions pass by default so make this fail to test if failure is set
 		actionStub.rejects(new Error('Something went wrong'));
@@ -84,9 +85,10 @@ describe('src/main', () => {
 
 		// Check that requires modules were initilized before running the action
 		expect(ghUtilStub).to.have.been.calledWith('ghTokenExample');
+		// Prefer balenaApiKey input over deprecated balenaToken
 		expect(balenaUtilStub).to.have.been.calledWith(
 			'balena-cloud.com',
-			'balenaTokenExample',
+			'balenaApiKeyExample',
 		);
 
 		while (!actionStub.lastCall) {
@@ -98,6 +100,7 @@ describe('src/main', () => {
 		// Check that the action was given correct input parameters
 		// Not checking first input which is the context as this is loaded by the github module
 		expect(actionStub.lastCall.args[1]).to.deep.equal({
+			balenaApiKey: 'balenaApiKeyExample',
 			balenaToken: 'balenaTokenExample',
 			fleet: 'my-org/my-fleet',
 			environment: 'balena-cloud.com',


### PR DESCRIPTION
As Flowzone uses passes the `balena_api_key` input, we should move to this as the primary interface instead of `balena_token`. `balena_token` is still supported for backwards compatibility.

Closes: #213
Change-type: patch
Signed-off-by: Christina Ying Wang <christina@balena.io>