### PR TITLE
Remove versionbot reference from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Inputs are provided using the `with:` section of your workflow YML file.
 | fleet | The slug of the fleet (eg: `my_org/sample_fleet`) for which the release is for | true | |
 | environment | Domain of API hosting your fleets | false | balena-cloud.com |
 | cache | If a release matching the commit already exists do not build again | false | true |
-| versionbot | Tells action to use Versionbot branch for versioning | false | false |
 | create_tag | Create a tag on the git commit with the final release version | false | false |
 | source | Specify a source directory (for `Dockerfile.template` or `docker-compose.yml`) | false | root directory |
 | layer_cache | Use cached layers of previously built images for this project | false | true |

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: balena-cloud.com
   versionbot:
-    description: Does the repository use VersionBot ?
+    description: (Deprecated) Does the repository use VersionBot?
     required: false
     default: false
   finalize:


### PR DESCRIPTION
Versionbot will be deprecated soon. This PR amends the README to avoid users implementing something planned to be removed as part of the phase out. A separate issue has been created to remove it from the code when the time comes. 

https://github.com/balena-io/deploy-to-balena-action/issues/238

https://balena.zulipchat.com/#narrow/stream/345749-loop.2FbalenaLabs/topic/Flowzone/near/319159610