### PR TITLE
Add deployment tests

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -18,3 +18,26 @@ jobs:
     with:
       docker_images: |
         ghcr.io/balena-io/deploy-to-balena-action
+
+  test-deploy-to-cloud:
+    name: Test deploy to balenaCloud
+    runs-on: ubuntu-latest
+    needs: flowzone
+    if: github.event.action != 'closed'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Replace the build image and Dockerfile for testing
+        run: |
+          # Use the Docker image built from the PR
+          yq e -i '.runs.image = "docker://ghcr.io/balena-io/deploy-to-balena-action:${{ github.event.pull_request.head.sha }}"' \
+            action.yml
+          # Overwrite the Dockerfile with minimal number of steps so the test deploy finishes quickly
+          echo FROM busybox > Dockerfile
+
+      - name: Deploy to a test fleet
+        uses: ./
+        with:
+          balena_token: ${{ secrets.BALENA_API_KEY }}
+          fleet: balena/deploy_to_balena_action
+          cache: false


### PR DESCRIPTION
Adds a deploy to Cloud test to run after Flowzone completes.

The test:
- Edits the `action.yml` to tell it to point to the docker image built by Flowzone in the build step before. 
- Overwrites the Dockerfile with a simple busy box image so the test completes quicker than trying to deploy the entire deploy-to-balena Dockerfile just for a deploy test
- Pushes to a test fleet to ensure it works. 