### PR TITLE
Add debug build logs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Inputs are provided using the `with:` section of your workflow YML file.
 | registry_secrets | JSON string containing image registry credentials used to pull base images | false | |
 | default_branch | Used to finalize a release when code is pushed to this branch | false | Repo configured [default branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch) |
 | multi_dockerignore | Respect .dockerignore in each service | false | false |
+| debug | Enable debug logs for balena push build | false | false |
 
 `balena_token` and other tokens needs to be stored in GitHub as an [encrypted secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) that GitHub Actions can access. 
 

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,10 @@ inputs:
     description: Use service's dockerignore file
     required: false
     default: false
+  debug:
+    description: Enable debug logs for balena push build
+    required: false
+    default: false
 outputs:
   release_id:
     description: ID of the release built

--- a/src/action.ts
+++ b/src/action.ts
@@ -137,6 +137,7 @@ export async function run(
 			...buildOptions,
 			noCache: inputs.layerCache === false,
 			multiDockerignore: inputs.multiDockerignore,
+			debug: inputs.debug,
 		});
 	} catch (e: any) {
 		core.error(e.message);

--- a/src/balena-utils.ts
+++ b/src/balena-utils.ts
@@ -22,12 +22,14 @@ type BuildOptions = {
 	draft: boolean;
 	tags: Tags;
 	multiDockerignore: boolean;
+	debug: boolean;
 };
 
 const DEFAULT_BUILD_OPTIONS: Partial<BuildOptions> = {
 	draft: true,
 	noCache: false,
 	multiDockerignore: false,
+	debug: false,
 };
 
 let sdk: ReturnType<typeof balena.getSdk> | null = null;
@@ -103,6 +105,10 @@ export async function push(
 
 	if (buildOpt.multiDockerignore) {
 		pushOpt.push('--multi-dockerignore');
+	}
+
+	if (buildOpt.debug) {
+		pushOpt.push('--debug');
 	}
 
 	let releaseId: string | null = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ const inputs: Inputs = {
 	layerCache: core.getBooleanInput('layer_cache', { required: false }),
 	defaultBranch: core.getInput('default_branch', { required: false }),
 	multiDockerignore: core.getBooleanInput('multi_dockerignore', { required: false }),
+	debug: core.getBooleanInput('debug', { required: false }),
 };
 
 (async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export type Inputs = {
 	layerCache: boolean;
 	defaultBranch: string;
 	multiDockerignore: boolean;
+	debug: boolean;
 };
 
 export type RepoContext = {

--- a/tests/src/action.spec.ts
+++ b/tests/src/action.spec.ts
@@ -32,6 +32,7 @@ const inputs: Partial<Inputs> = {
 	layerCache: true,
 	defaultBranch: '',
 	multiDockerignore: true,
+	debug: true,
 };
 
 describe('src/action', () => {
@@ -137,6 +138,7 @@ describe('src/action', () => {
 		expect(pushStub.lastCall.lastArg).to.deep.equal({
 			draft: false,
 			multiDockerignore: true,
+			debug: true,
 			noCache: true,
 			tags: {
 				sha: 'fba0317620597271695087c168c50d8c94975a29',
@@ -182,6 +184,7 @@ describe('src/action', () => {
 			// Check that the last arg (buildOptions) does not contain draft: true
 			expect(pushStub.lastCall.lastArg).to.deep.equal({
 				multiDockerignore: true,
+				debug: true,
 				noCache: false,
 				tags: {
 					sha: 'fba0317620597271695087c168c50d8c94975a29',
@@ -238,6 +241,7 @@ describe('src/action', () => {
 				noCache: false,
 				draft: false,
 				multiDockerignore: true,
+				debug: true,
 				tags: {
 					sha: 'fba0317620597271695087c168c50d8c94975a29',
 				},
@@ -261,6 +265,7 @@ describe('src/action', () => {
 			expect(pushStub.lastCall.lastArg).to.deep.equal({
 				noCache: false,
 				multiDockerignore: true,
+				debug: true,
 				draft: false,
 				tags: {
 					sha: 'fba0317620597271695087c168c50d8c94975a29',

--- a/tests/src/balena-utils.spec.ts
+++ b/tests/src/balena-utils.spec.ts
@@ -127,7 +127,7 @@ describe('src/balena-utils', () => {
 			]);
 		});
 
-		it('Sets --draft, --nocache and --multi-dockerignore', async () => {
+		it('Sets --draft, --nocache and --multi-dockerignore and --debug', async () => {
 			setTimeout(() => {
 				mockProcess.emit('exit', 0); // make process exit
 			}, 500);
@@ -137,6 +137,7 @@ describe('src/balena-utils', () => {
 					noCache: true,
 					draft: true,
 					multiDockerignore: true,
+					debug: true,
 					tags: { sha: 'fba0317620597271695087c168c50d8c94975a29' },
 				});
 			} catch (e) {
@@ -154,6 +155,7 @@ describe('src/balena-utils', () => {
 				'--draft',
 				'--nocache',
 				'--multi-dockerignore',
+				'--debug',
 			]);
 		});
 

--- a/tests/src/main.spec.ts
+++ b/tests/src/main.spec.ts
@@ -56,6 +56,7 @@ describe('src/main', () => {
 				create_ref: false,
 				layer_cache: true,
 				multi_dockerignore: true,
+				debug: true,
 			}[inputName];
 		});
 	});
@@ -110,6 +111,7 @@ describe('src/main', () => {
 			layerCache: true,
 			defaultBranch: '',
 			multiDockerignore: true,
+			debug: true,
 		});
 		// Since github actions pass by default there's no need to check if the action passes
 		// So, let's check if the action correctly handles failures instead


### PR DESCRIPTION
Change-type: minor

This change adds an option to use the `--debug` flag to the Balena push command to allow to see debug build logs.

This PR has been modeled after a similar PR to add the `--multi-dockerignore` flag [here](https://github.com/balena-io/deploy-to-balena-action/pull/249)