### PR TITLE
Enable adding a note to the release

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Inputs are provided using the `with:` section of your workflow YML file.
 | default_branch | Used to finalize a release when code is pushed to this branch | false | Repo configured [default branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch) |
 | multi_dockerignore | Respect .dockerignore in each service | false | false |
 | debug | Enable debug logs for balena push build | false | false |
+| note | Enable adding a note to the release | false | |
 
 `balena_token` and other tokens needs to be stored in GitHub as an [encrypted secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) that GitHub Actions can access. 
 

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,10 @@ inputs:
     description: Enable debug logs for balena push build
     required: false
     default: "false"
+  note:
+    description: Enable adding a note to the release
+    required: false
+    default: ""
 outputs:
   release_id:
     description: ID of the release built

--- a/src/action.ts
+++ b/src/action.ts
@@ -138,6 +138,7 @@ export async function run(
 			noCache: inputs.layerCache === false,
 			multiDockerignore: inputs.multiDockerignore,
 			debug: inputs.debug,
+			note: inputs.note,
 		});
 	} catch (e: any) {
 		core.error(e.message);

--- a/src/balena-utils.ts
+++ b/src/balena-utils.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import { exec } from '@actions/exec';
-import { spawn } from 'child_process';
 import * as balena from 'balena-sdk';
+import { spawn } from 'child_process';
 
 import { Release } from './types';
 
@@ -23,6 +23,7 @@ type BuildOptions = {
 	tags: Tags;
 	multiDockerignore: boolean;
 	debug: boolean;
+	note: string;
 };
 
 const DEFAULT_BUILD_OPTIONS: Partial<BuildOptions> = {
@@ -30,6 +31,7 @@ const DEFAULT_BUILD_OPTIONS: Partial<BuildOptions> = {
 	noCache: false,
 	multiDockerignore: false,
 	debug: false,
+	note: "",
 };
 
 let sdk: ReturnType<typeof balena.getSdk> | null = null;
@@ -109,6 +111,14 @@ export async function push(
 
 	if (buildOpt.debug) {
 		pushOpt.push('--debug');
+	}
+
+	if (buildOpt.note.trim()) {
+		pushOpt.push('--note');
+
+		// sanitize note string to escape quotes
+		const note = buildOpt.note.trim().replace(/"/g, '\\"').replace(/'/g, "\\'");
+		pushOpt.push(`"${note}"`);
 	}
 
 	let releaseId: string | null = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ const inputs: Inputs = {
 	defaultBranch: core.getInput('default_branch', { required: false }),
 	multiDockerignore: core.getBooleanInput('multi_dockerignore', { required: false }),
 	debug: core.getBooleanInput('debug', { required: false }),
+	note: core.getInput('note', { required: false }),
 };
 
 (async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type Inputs = {
 	defaultBranch: string;
 	multiDockerignore: boolean;
 	debug: boolean;
+	note: string;
 };
 
 export type RepoContext = {

--- a/tests/src/action.spec.ts
+++ b/tests/src/action.spec.ts
@@ -33,6 +33,7 @@ const inputs: Partial<Inputs> = {
 	defaultBranch: '',
 	multiDockerignore: true,
 	debug: true,
+	note: 'My useful note',
 };
 
 describe('src/action', () => {
@@ -139,6 +140,7 @@ describe('src/action', () => {
 			draft: false,
 			multiDockerignore: true,
 			debug: true,
+			note: 'My useful note',
 			noCache: true,
 			tags: {
 				sha: 'fba0317620597271695087c168c50d8c94975a29',
@@ -185,6 +187,7 @@ describe('src/action', () => {
 			expect(pushStub.lastCall.lastArg).to.deep.equal({
 				multiDockerignore: true,
 				debug: true,
+				note: 'My useful note',
 				noCache: false,
 				tags: {
 					sha: 'fba0317620597271695087c168c50d8c94975a29',
@@ -242,6 +245,7 @@ describe('src/action', () => {
 				draft: false,
 				multiDockerignore: true,
 				debug: true,
+				note: 'My useful note',
 				tags: {
 					sha: 'fba0317620597271695087c168c50d8c94975a29',
 				},
@@ -266,6 +270,7 @@ describe('src/action', () => {
 				noCache: false,
 				multiDockerignore: true,
 				debug: true,
+				note: 'My useful note',
 				draft: false,
 				tags: {
 					sha: 'fba0317620597271695087c168c50d8c94975a29',

--- a/tests/src/balena-utils.spec.ts
+++ b/tests/src/balena-utils.spec.ts
@@ -127,7 +127,7 @@ describe('src/balena-utils', () => {
 			]);
 		});
 
-		it('Sets --draft, --nocache and --multi-dockerignore and --debug', async () => {
+		it('Sets --draft, --nocache and --multi-dockerignore and --debug and --note', async () => {
 			setTimeout(() => {
 				mockProcess.emit('exit', 0); // make process exit
 			}, 500);
@@ -138,6 +138,7 @@ describe('src/balena-utils', () => {
 					draft: true,
 					multiDockerignore: true,
 					debug: true,
+					note: 'My useful note',
 					tags: { sha: 'fba0317620597271695087c168c50d8c94975a29' },
 				});
 			} catch (e) {
@@ -156,6 +157,8 @@ describe('src/balena-utils', () => {
 				'--nocache',
 				'--multi-dockerignore',
 				'--debug',
+				'--note',
+				'"My useful note"',
 			]);
 		});
 

--- a/tests/src/main.spec.ts
+++ b/tests/src/main.spec.ts
@@ -44,6 +44,7 @@ describe('src/main', () => {
 				source: dynamicSource,
 				github_token: 'ghTokenExample',
 				default_branch: '',
+				note: 'My useful note',
 			}[inputName];
 		});
 
@@ -112,6 +113,7 @@ describe('src/main', () => {
 			defaultBranch: '',
 			multiDockerignore: true,
 			debug: true,
+			note: 'My useful note',
 		});
 		// Since github actions pass by default there's no need to check if the action passes
 		// So, let's check if the action correctly handles failures instead


### PR DESCRIPTION
This change adds an option to use the --debug flag to the Balena push command to allow to see debug build logs.

This PR has been modeled after a similar PR to add the --multi-dockerignore flag [here](https://github.com/balena-io/deploy-to-balena-action/pull/249)

Change-type: minor