### PR TITLE
Drop support for node 16 and npm 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "typescript"
   ],
   "engines": {
-    "npm": ">=8.0.0",
-    "node": ">=16.0.0"
+    "npm": ">=9.0.0",
+    "node": ">=18.0.0"
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
This release drops support for Node.js 16, which is EOL after 2023-09-11.
Please upgrade your Node.js to the latest version.

Change-type: major