### PR TITLE
Append a newline to the package-lock with versionist

### DIFF
--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -32,7 +32,7 @@ module.exports = {
     const packageLockData = require(packageLockFile);
     packageLockData.version = version;
     packageLockData.packages[""].version = version;
-    fs.writeFileSync(packageLockFile, JSON.stringify(packageLockData, null, 2));
+    fs.writeFileSync(packageLockFile, JSON.stringify(packageLockData, null, 2) + '\n');
     const actionYml = `${cwd}/action.yml`;
     const action = yaml.parse(fs.readFileSync(actionYml, 'utf8'));
     action.runs.image = action.runs.image.replace(regex, `$1:v${version}`);


### PR DESCRIPTION
Renovate's lock-file maintenance includes a newline so avoid recursive commits and avoid stripping it.

Change-type: patch