### PR TITLE
Fix catch of reference already exists errors

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -71,7 +71,7 @@ export async function run(
 				try {
 					await github.createTag(repoContext, rawVersion);
 				} catch (e: any) {
-					if (e.message !== 'Reference already exists') {
+					if (e.response?.data?.message !== 'Reference already exists') {
 						throw e;
 					}
 					core.info('Git reference already exists.');
@@ -155,7 +155,7 @@ export async function run(
 		try {
 			await github.createTag(repoContext, rawVersion);
 		} catch (e: any) {
-			if (e.message !== 'Reference already exists') {
+			if (e.response?.data?.message !== 'Reference already exists') {
 				throw e;
 			}
 			core.info('Git reference already exists.');


### PR DESCRIPTION
This catch was supposed to prevent an abort when the error
was 'Reference already exists' but octokit appends the documentation_url
property to the top level error message field.