### PR TITLE
Pin balena CLI to v24

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>balena-io/renovate-config"],
+  "packageRules": [
+    {
+      "description": "Hold balena CLI at v24 until the builder compose parser aligns with v25. See https://github.com/balena-io-modules/balena-compose-parser/issues/27",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["balena-io/balena-cli"],
+      "allowedVersions": "<25.0.0"
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     rm -rf /var/lib/apt/lists/*
 
 # renovate: datasource=github-releases depName=balena-io/balena-cli
-ARG BALENA_CLI_VERSION=v25.1.7
+ARG BALENA_CLI_VERSION=v24.1.4
 
 # Install balena-cli via standlone zip to save install time
 RUN wget -qO- "https://github.com/balena-io/balena-cli/releases/download/${BALENA_CLI_VERSION}/balena-cli-${BALENA_CLI_VERSION}-linux-x64-standalone.tar.gz" | tar -xzf -


### PR DESCRIPTION
v25 resolves compose variable interpolation at parse time against the host env instead of deferring to the runtime shell. That silently bakes empty values into the image config, and it isn't portable: the builder still runs the old parser, so neither `$VAR` nor `$$VAR` is correct across both build paths.

Pin to v24.1.4 and cap Renovate at `<25.0.0` until the builder parser aligns. This repo had no renovate config before, so the new `.github/renovate.json` extends `github>balena-io/renovate-config` to keep the org defaults.

See: https://github.com/balena-io-modules/balena-compose-parser/issues/27
